### PR TITLE
Add travis scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@ To build a package, run the following in a bash terminal:
 $ sh package.sh my-package path/to/custom/wiremock.jar
 ```
 
-When called successfully, the new package will be created in the current directory. The server can be run using the provided launch script:
+When called successfully, the new package (both a directory and zip) will be created in the current directory. The server can be run using the provided launch script:
 
 ```bash
 $ sh my-package/launch.sh
 ```
+
+## Releasing a Package
+To release a package, create a new release in GitHub and upload the ZIP file created in [Building Packages](#building-packages). When you are ready for the SDKs running Travis to start using your package, update the download link in the Travis install script [Updating Release in Install Script](#updating-release-in-install-script)
 
 ## Using with Travis CI
 Travis can use this package to run the Smartsheet WireMock mock API server. This package contains two scripts to use with Travis: an install script and a start script. The install script downloads a WireMock bundle unzips it. The start script runs WireMock in the background and waits for WireMock to warm-up.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # wiremock-scenario-templating
 A script for packaging a custom WireMock server.
 
-## Usage
+## Building Packages
 To build a package, run the following in a bash terminal:
 
 ```bash
@@ -13,3 +13,23 @@ When called successfully, the new package will be created in the current directo
 ```bash
 $ sh my-package/launch.sh
 ```
+
+## Using with Travis CI
+Travis can use this package to run the Smartsheet WireMock mock API server. This package contains two scripts to use with Travis: an install script and a start script. The install script downloads a WireMock bundle unzips it. The start script runs WireMock in the background and waits for WireMock to warm-up.
+
+### Configuring SDKs to Run the Mock API
+Add the following to your SDKs `.travis.yml` configuration file to run the WireMock server:
+
+```yaml
+before_install:
+  - git clone https://github.com/stollgr/wiremock-scenario-templating.git
+  - wiremock-scenario-templating/travis_scripts/install_wiremock.sh
+  # install SDK dependencies
+
+script:
+  - wiremock-scenario-templating/travis_scripts/start_wiremock.sh
+  # run SDK specific functional and mock API tests
+```
+
+### Updating Release in Install Script
+The install script currently downloads the WireMock bundle based on a hard-coded string. To update this, you will need to update the `RELEASE_DOWNLOAD_URL` variable in travis_scripts/install_wiremock.sh. Once this has been updated and pushed to master, any future SDK Travis builds will run using the new mock server release

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # wiremock-scenario-templating
-A script for packaging a custom WireMock server.
+Scripts for packaging and deploying a custom WireMock server.
 
-## Building Packages
-To build a package, run the following in a bash terminal:
+## Usage
+This repository provides a number of scripts that can be used to bundle a WireMock server with Smartsheet scenario configuration files. It also contains scripts that can be used by Travis builds to install and run a WireMock server bundle.
+
+## Bundling Packages
+To bundle a package, run the following in a bash terminal:
 
 ```bash
 $ sh package.sh my-package path/to/custom/wiremock.jar
@@ -15,24 +18,37 @@ $ sh my-package/launch.sh
 ```
 
 ## Releasing a Package
-To release a package, create a new release in GitHub and upload the ZIP file created in [Building Packages](#building-packages). When you are ready for the SDKs running Travis to start using your package, update the download link in the Travis install script [Updating Release in Install Script](#updating-release-in-install-script)
+To release a package, create a new release in GitHub and upload the ZIP file created in [Bundling Packages](#bundling-packages). When you are ready for Travis to start using your new package, follow the instructions in [Updating Release in Travis](#updating-release-in-travis)
 
 ## Using with Travis CI
 Travis can use this package to run the Smartsheet WireMock mock API server. This package contains two scripts to use with Travis: an install script and a start script. The install script downloads a WireMock bundle unzips it. The start script runs WireMock in the background and waits for WireMock to warm-up.
 
 ### Configuring SDKs to Run the Mock API
-Add the following to your SDKs `.travis.yml` configuration file to run the WireMock server:
+Add the following to your SDK's `.travis.yml` configuration file to run the WireMock server:
 
 ```yaml
 before_install:
   - git clone https://github.com/stollgr/wiremock-scenario-templating.git
   - wiremock-scenario-templating/travis_scripts/install_wiremock.sh
-  # install SDK dependencies
 
 script:
   - wiremock-scenario-templating/travis_scripts/start_wiremock.sh
   # run SDK specific functional and mock API tests
 ```
 
-### Updating Release in Install Script
-The install script currently downloads the WireMock bundle based on a hard-coded string. To update this, you will need to update the `RELEASE_DOWNLOAD_URL` variable in travis_scripts/install_wiremock.sh. Once this has been updated and pushed to master, any future SDK Travis builds will run using the new mock server release
+For example, the Node SDK's `.travis.yml` configuration is:
+
+```yaml
+before_install:
+  - git clone https://github.com/stollgr/wiremock-scenario-templating.git
+  - wiremock-scenario-templating/travis_scripts/install_wiremock.sh
+
+script:
+  - wiremock-scenario-templating/travis_scripts/start_wiremock.sh
+  - npm test
+```
+
+Follow the instructions in [Updating Release in Travis](#updating-release-in-travis) to configure the current release.
+
+### Updating Release in Travis
+The install script currently downloads the WireMock bundle based on the `MOCK_API_RELEASE_URL` environment variable. To update this, you will need to update the `MOCK_API_RELEASE_URL` variable in each of the SDK-specific Travis jobs. See [here](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings) for more information about configuring environment variables in Travis.

--- a/package.sh
+++ b/package.sh
@@ -52,3 +52,7 @@ cp $WIREMOCK_JAR "$PACKAGE_NAME/wiremock.jar"
 
 # add launch script
 cp $LAUNCH_SCRIPT "$PACKAGE_NAME/launch.sh"
+
+# create zip
+(cd $PACKAGE_NAME; zip -q -r "$PACKAGE_NAME.zip" *)
+mv "$PACKAGE_NAME/$PACKAGE_NAME.zip" .

--- a/travis_scripts/install_wiremock.sh
+++ b/travis_scripts/install_wiremock.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+WIREMOCK_DOWNLOAD='Smartsheet-WireMock-Bundle.zip'
+WIREMOCK_INSTALL_DIR='Smartsheet-WireMock-Bundle'
+RELEASE_DOWNLOAD_URL='https://github.com/stollgr/wiremock-scenario-templating/releases/download/0.12/Smartsheet-WireMock-Bundle.zip'
+
+# download wiremock
+curl $RELEASE_DOWNLOAD_URL -L -s -o $WIREMOCK_DOWNLOAD
+
+# unzip wiremock
+unzip -qq $WIREMOCK_DOWNLOAD

--- a/travis_scripts/install_wiremock.sh
+++ b/travis_scripts/install_wiremock.sh
@@ -2,10 +2,14 @@
 
 WIREMOCK_DOWNLOAD='Smartsheet-WireMock-Bundle.zip'
 WIREMOCK_INSTALL_DIR='Smartsheet-WireMock-Bundle'
-RELEASE_DOWNLOAD_URL='https://github.com/stollgr/wiremock-scenario-templating/releases/download/0.12/Smartsheet-WireMock-Bundle.zip'
+
+if [ -z "$MOCK_API_RELEASE_URL" ]; then
+    echo "Must set MOCK_API_RELEASE_URL environment variable"
+    exit 1
+fi
 
 # download wiremock
-curl $RELEASE_DOWNLOAD_URL -L -s -o $WIREMOCK_DOWNLOAD
+curl $MOCK_API_RELEASE_URL -L -s -o $WIREMOCK_DOWNLOAD
 
 # unzip wiremock
 unzip -qq -d $WIREMOCK_INSTALL_DIR $WIREMOCK_DOWNLOAD

--- a/travis_scripts/install_wiremock.sh
+++ b/travis_scripts/install_wiremock.sh
@@ -8,4 +8,4 @@ RELEASE_DOWNLOAD_URL='https://github.com/stollgr/wiremock-scenario-templating/re
 curl $RELEASE_DOWNLOAD_URL -L -s -o $WIREMOCK_DOWNLOAD
 
 # unzip wiremock
-unzip -qq $WIREMOCK_DOWNLOAD
+unzip -qq -d $WIREMOCK_INSTALL_DIR $WIREMOCK_DOWNLOAD

--- a/travis_scripts/start_wiremock.sh
+++ b/travis_scripts/start_wiremock.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+WIREMOCK_INSTALL_DIR='Smartsheet-WireMock-Bundle'
+
+# run wiremock
+(cd $WIREMOCK_INSTALL_DIR; ./launch.sh &)
+
+# wait for wiremock to start
+sleep 5


### PR DESCRIPTION
These scripts will be used by the various SDK repos to download and start wiremock. I have a working test of them here: https://travis-ci.org/smartsheet-platform/smartsheet-ruby-sdk/jobs/295027130